### PR TITLE
cell sample form simplification

### DIFF
--- a/rotmic/adminSamples.py
+++ b/rotmic/adminSamples.py
@@ -273,12 +273,13 @@ class CellSampleAdmin( reversion.VersionAdmin, SampleAdmin ):
                     ))
             } ),
          ('Content', {
-             'fields' : ((('cell',),
+             'fields' : ((
+                          ('cell',),
                           ('plasmid', 'cellCategory', 'cellType'),
                           ('amount','amountUnit',),
                           ('solvent','aliquotNr',),
                         )),
-             'description': 'Select an <b>existing</b> Cell record <b>or</b> create a <b>new Cell</b> record on the fly from plasmid + strain below.'
+             ## 'description': 'Select an existing Cell record <b>or</b> specify plasmid + strain below.' ## cell field hidden in form
          }
         ), 
     ]

--- a/rotmic/adminSamples.py
+++ b/rotmic/adminSamples.py
@@ -275,7 +275,8 @@ class CellSampleAdmin( reversion.VersionAdmin, SampleAdmin ):
          ('Content', {
              'fields' : ((
                           ('cell',),
-                          ('plasmid', 'cellCategory', 'cellType'),
+                          ('plasmid', 'cellType'),
+##                          ('plasmid', 'cellCategory', 'cellType'),
                           ('amount','amountUnit',),
                           ('solvent','aliquotNr',),
                         )),

--- a/rotmic/forms/sampleForms.py
+++ b/rotmic/forms/sampleForms.py
@@ -290,7 +290,7 @@ class CellSampleForm( SampleForm ):
     
     class Meta:
         model = M.CellSample
-##        widgets = getSampleWidgets( \
+        widgets = getSampleWidgets()
 ##            {'cell': sforms.AutoComboboxSelectWidget(lookup_class=L.SampleCellLookup,
 ##                                                    allow_new=False,
 ##                                                    attrs={'size':35}),

--- a/rotmic/forms/sampleForms.py
+++ b/rotmic/forms/sampleForms.py
@@ -198,7 +198,7 @@ class CellSampleForm( SampleForm ):
     
     cellType = forms.ModelChoiceField(label='Strain',
                             queryset=M.CellComponentType.objects.exclude(subTypeOf=None),
-                            required=False,
+                            required=True,  ## note change to False, if cell field is re-activated
                             empty_label=None,
                             initial=T.ccMach1)
     
@@ -215,7 +215,12 @@ class CellSampleForm( SampleForm ):
         super(CellSampleForm, self).__init__(*args, **kwargs)
 
         ## keep constraint on DB level but allow user to specify via plasmid+type
-        self.fields['cell'].required = False
+        f = self.fields['cell']
+        f.required = False
+        
+        ## hide the cell field from the form to reduce complexity
+        f.widget = forms.HiddenInput()
+        f.label = f.help_text = ''
 
         o = kwargs.get('instance', None)
         if o:
@@ -285,11 +290,11 @@ class CellSampleForm( SampleForm ):
     
     class Meta:
         model = M.CellSample
-        widgets = getSampleWidgets( \
-            {'cell': sforms.AutoComboboxSelectWidget(lookup_class=L.SampleCellLookup,
-                                                    allow_new=False,
-                                                    attrs={'size':35}),
-             })
+##        widgets = getSampleWidgets( \
+##            {'cell': sforms.AutoComboboxSelectWidget(lookup_class=L.SampleCellLookup,
+##                                                    allow_new=False,
+##                                                    attrs={'size':35}),
+##             })
 
         
 class OligoSampleForm( SampleForm ):

--- a/rotmic/forms/sampleForms.py
+++ b/rotmic/forms/sampleForms.py
@@ -188,13 +188,24 @@ class DnaSampleForm( SampleForm ):
 
 
 class CellSampleForm( SampleForm ):
-    """Customized Form for CellSample add / change"""
+    """
+    Customized Form for CellSample add / change
     
-    cellCategory = forms.ModelChoiceField(label='In Species',
-                            queryset=M.CellComponentType.objects.filter(subTypeOf=None),
-                            required=False, 
-                            empty_label=None,
-                            initial=T.ccEcoli)
+    Note:
+    until v1.1.0, this form allowed to select either an existing cell record
+    directly or to specifiy plasmid + strain and have the cell record created
+    or linked in the background.
+    
+    The option to select cell records directly has been removed -- all the 
+    relevant code is merely commented out (see also sampleAdmin) so that it 
+    can be activated again if needed.
+    """
+    
+##    cellCategory = forms.ModelChoiceField(label='In Species',
+##                            queryset=M.CellComponentType.objects.filter(subTypeOf=None),
+##                            required=False, 
+##                            empty_label=None,
+##                            initial=T.ccEcoli)
     
     cellType = forms.ModelChoiceField(label='Strain',
                             queryset=M.CellComponentType.objects.exclude(subTypeOf=None),
@@ -224,7 +235,7 @@ class CellSampleForm( SampleForm ):
 
         o = kwargs.get('instance', None)
         if o:
-            self.fields['cellCategory'].initial = o.cell.componentType.category()
+##            self.fields['cellCategory'].initial = o.cell.componentType.category()
             self.fields['cellType'].initial = o.cell.componentType
             self.fields['plasmid'].initial = o.cell.plasmid
 
@@ -238,52 +249,53 @@ class CellSampleForm( SampleForm ):
         plasmid = data.get('plasmid', None)
         ctype = data.get('cellType', None)
         
-        if not cell and not (plasmid and ctype):
-            msg = u'Please specify either an existing cell or a plasmid and strain.'
-            self._errors['cell'] = self.error_class([msg])
-            try: 
-                del data['cell'] ## needed to really stop form saving
-            except: 
-                pass
+##        if not cell and not (ctype):
+##            msg = u'Please specify plasmid and strain or, at least, a strain (i.e. for competent cells w/o plasmid).'
+##            self._errors['cell'] = self.error_class([msg])
+##            try: 
+##                del data['cell'] ## needed to really stop form saving
+##            except: 
+##                pass
+##            
+##        elif plasmid and cell:
+##            if plasmid != cell.plasmid:
+##                msg = u'Given plasmid does not match selected cell record. Remove one or the other.'
+##                self._errors['plasmid'] = self.error_class([msg])
+##                del data['plasmid']
+##            if ctype != cell.componentType:
+##                msg = u'Given strain does not match selected cell record. Clear either plasmid or cell selection.'
+##                self._errors['cellType'] = self.error_class([msg])
+##                del data['cellType']
+##            
+##        if (not cell) and ctype:
             
-        elif plasmid and cell:
-            if plasmid != cell.plasmid:
-                msg = u'Given plasmid does not match selected cell record. Remove one or the other.'
-                self._errors['plasmid'] = self.error_class([msg])
-                del data['plasmid']
-            if ctype != cell.componentType:
-                msg = u'Given strain does not match selected cell record. Clear either plasmid or cell selection.'
-                self._errors['cellType'] = self.error_class([msg])
-                del data['cellType']
+        existing = M.CellComponent.objects.filter(plasmid=plasmid,
+                                                componentType=ctype)
+        if existing.count():
+            data['cell'] = existing.all()[0]
+            messages.success(self.request, 
+                             'Attached existing cell record %s (%s) to sample.'\
+                             % (data['cell'].displayId, data['cell'].name))
+        
+        else:
+            plasmidname = plasmid.name if plasmid else ''
+            newcell = M.CellComponent(componentType=ctype,
+                                    plasmid=plasmid,
+                                    displayId=M.CellComponent.nextAvailableId(self.request.user),
+                                    registeredBy = self.request.user,
+                                    registeredAt = datetime.datetime.now(),
+                                    name = plasmidname + '@' + ctype.name,
+                                    )
+            newcell.save()
+            ## Many2Many relationships can only be created after save
+            newcell.authors = [self.request.user]
+            newcell.projects = plasmid.projects.all() if plasmid else []
+            newcell.save()
             
-        if (not cell) and plasmid:
-            
-            existing = M.CellComponent.objects.filter(plasmid=plasmid,
-                                                    componentType=ctype)
-            if existing.count():
-                data['cell'] = existing.all()[0]
-                messages.success(self.request, 
-                                 'Attached existing cell record %s (%s) to sample.'\
-                                 % (data['cell'].displayId, data['cell'].name))
-            
-            else:
-                newcell = M.CellComponent(componentType=ctype,
-                                        plasmid=plasmid,
-                                        displayId=M.CellComponent.nextAvailableId(self.request.user),
-                                        registeredBy = self.request.user,
-                                        registeredAt = datetime.datetime.now(),
-                                        name = plasmid.name + '@' + ctype.name,
-                                        )
-                newcell.save()
-                ## Many2Many relationships can only be created after save
-                newcell.authors = [self.request.user]
-                newcell.projects = plasmid.projects.all()
-                newcell.save()
-                
-                data['cell'] = newcell
-                messages.success(self.request,
-                                 'Created new cell record %s (%s)' %\
-                                 (newcell.displayId, newcell.name))
+            data['cell'] = newcell
+            messages.success(self.request,
+                             'Created new cell record %s (%s)' %\
+                             (newcell.displayId, newcell.name))
 
         return data
     

--- a/rotmic/templates/admin/rotmic/cellsample/change_form.html
+++ b/rotmic/templates/admin/rotmic/cellsample/change_form.html
@@ -2,7 +2,8 @@
 
 
 {% block func_extra %}
-{# <script charset="utf-8" type="text/javascript">  #}
+{# ## stopped working, re-implement using django-selectable example #}
+{# but for some reason, position completion stops working if this js is commented out #}
 
     // fetch all sub-types of given Category (Species) and fill cellType listbox
     // needs to be called as event from CategoryBox (assuming $(this) is sender
@@ -31,7 +32,7 @@
         $("#id_cellCategory").attr('selected', 'selected');
     }
   
-{# </script> #}
+
 {% endblock %}
 
 {% block bind_extra %}


### PR DESCRIPTION
Removes the option to directly select an existing cell record from the cell sample form.
Also removes "Species" drop down as the js chaining with the strain drop-down stopped working.